### PR TITLE
Add country to URL query. Fixes #14

### DIFF
--- a/lib/googlebooks.rb
+++ b/lib/googlebooks.rb
@@ -36,6 +36,7 @@ module GoogleBooks
       parameters['maxResults'] = options[:count]
       parameters['key'] = options[:api_key] if options[:api_key]
       parameters['orderBy'] = 'newest' if options[:order_by].eql?('newest')
+      parameters['country'] = options[:country]
 
       Response.new(get(url.to_s))
     end

--- a/spec/googlebooks/googlebooks_spec.rb
+++ b/spec/googlebooks/googlebooks_spec.rb
@@ -30,12 +30,18 @@ describe GoogleBooks do
       GoogleBooks.send(:query).should include 'maxResults=20'
     end
     
+    it "should set the country" do
+      GoogleBooks.search('the great gatsby', :country => "ca")
+      GoogleBooks.send(:query).should include 'country=ca'
+    end
+    
     it "should join parameters" do
-      GoogleBooks.search('the great gatsby', :count => 20, :page => 2)
+      GoogleBooks.search('the great gatsby', :count => 20, :page => 2, :country => "ca")
       GoogleBooks.send(:query).should include 'startIndex=2'
       GoogleBooks.send(:query).should include 'maxResults=20'
       GoogleBooks.send(:query).should include 'q=the+great+gatsby'
-      GoogleBooks.send(:query).count('&').should eq 2 
+      GoogleBooks.send(:query).should include 'country=ca'
+      GoogleBooks.send(:query).count('&').should eq 3 
     end
     
     it "should return the proper number results based on the count passed in" do


### PR DESCRIPTION
This enables adding country to the GoogleBooks API request, needed for unidentifiable and overseas servers.
