### PR TITLE
Remove country when not defined in query options

### DIFF
--- a/lib/googlebooks.rb
+++ b/lib/googlebooks.rb
@@ -14,14 +14,14 @@ module GoogleBooks
     attr_accessor :parameters
 
     # Submits query to the current Google API for Books.
-		#
+    #
     # 1st param passes all varieties of acceptable query strings
-		#
+    #
     # 2nd param passes options hash:
     # * :count passes number of results to display per page (default=5)
     # * :page passes the page number (default=1)
     # * :api_key passes the application specific Google API key
-		#
+    #
     # 3rd parameter optionally passes user's IP address
     # * User IP may be require in order for request to be made to the
     #   Google API from applications residing on decentralized cloud servers
@@ -37,7 +37,7 @@ module GoogleBooks
       parameters['maxResults'] = options[:count]
       parameters['key'] = options[:api_key] if options[:api_key]
       parameters['orderBy'] = 'newest' if options[:order_by].eql?('newest')
-      parameters['country'] = options[:country]
+      parameters['country'] = options[:country] if options[:country]
 
       Response.new(get(url.to_s))
     end

--- a/spec/googlebooks/googlebooks_spec.rb
+++ b/spec/googlebooks/googlebooks_spec.rb
@@ -7,23 +7,23 @@ describe GoogleBooks do
       expect(GoogleBooks.send(:query)).to include 'q=the+great+gatsby'
     end
 
-		describe 'startIndex' do
-		  it "should default to 0 if no page is specified" do
-		  	GoogleBooks.search('the great gatsby')
-		  	expect(GoogleBooks.send(:query)).to include 'startIndex=0'
-		  end
-		  
-		  it "should calculate based on default count of 5 if no count is given" do
-		  	GoogleBooks.search("the great gatsby", :page => 4)
-		  	expect(GoogleBooks.send(:query)).to include 'startIndex=15'
-		  end
-		  
-		  it "should set based on page number and count" do
-		    GoogleBooks.search('the great gatsby', {:page => 3, :count => 12})
-		    expect(GoogleBooks.send(:query)).to include 'startIndex=24'
-		  end
-		  
-		end
+    describe 'startIndex' do
+      it "should default to 0 if no page is specified" do
+        GoogleBooks.search('the great gatsby')
+        expect(GoogleBooks.send(:query)).to include 'startIndex=0'
+      end
+      
+      it "should calculate based on default count of 5 if no count is given" do
+        GoogleBooks.search("the great gatsby", :page => 4)
+        expect(GoogleBooks.send(:query)).to include 'startIndex=15'
+      end
+      
+      it "should set based on page number and count" do
+        GoogleBooks.search('the great gatsby', {:page => 3, :count => 12})
+        expect(GoogleBooks.send(:query)).to include 'startIndex=24'
+      end
+      
+    end
 
     it "should set the number of results per page" do
       GoogleBooks.search('the great gatsby', :count => 20)
@@ -33,6 +33,11 @@ describe GoogleBooks do
     it "should set the country" do
       GoogleBooks.search('the great gatsby', :country => "ca")
       expect(GoogleBooks.send(:query)).to include 'country=ca'
+    end
+
+    it "should not set the country when not defined" do
+      GoogleBooks.search('the great gatsby')
+      expect(GoogleBooks.send(:query)).not_to include 'country='
     end
     
     it "should join parameters" do


### PR DESCRIPTION
Removes the inclusion of `country=` from the query parameters when not defined in the query options hash

Edit out some whitespace issues
