### PR TITLE
Add missing license to gemspec

### DIFF
--- a/googlebooks.gemspec
+++ b/googlebooks.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |s|
   s.description = %q{GoogleBooks is a lightweight Ruby wrapper that queries the Google API to search for publications in the Google Books repository. It is inspired by the google-book gem which relies on the deprecated Google GData Books API, but is updated to hook into the current Google API.}
 
   s.rubyforge_project = "googlebooks"
-
+  s.license = 'GPL-3'
+  
   s.add_dependency('httparty')
   s.add_development_dependency('rspec')
   s.add_development_dependency('webmock')


### PR DESCRIPTION
Some companies, organizations and individuals can only use gems with certain licenses. Rubygems make it easy to specify a license programatically via the 's.license' accessor. I'd like to add the license you've specified on the repository to your gemspec file.

http://guides.rubygems.org/make-your-own-gem/
