### PR TITLE
Fixed awkward title when subtitle is an empty string

### DIFF
--- a/lib/book/item.rb
+++ b/lib/book/item.rb
@@ -45,7 +45,8 @@ module GoogleBooks
 
     def build_title
       title = [@volume_info['title']].flatten.join(': ')
-      @volume_info['subtitle'].nil? ? title : title + ": " + @volume_info['subtitle']
+      subtitle_missing = @volume_info['subtitle'].nil? || @volume_info['subtitle'].length == 0
+      subtitle_missing ? title : title + ": " + @volume_info['subtitle']
     end
 
     def retrieve_industry_identifiers


### PR DESCRIPTION
Sometimes, the subtitle given by the Google Books API is an empty string (e.g. https://www.googleapis.com/books/v1/volumes?q=isbn:9786029225938). 

This PR tries to fix the awkward resulting title due to no empty string checking when building the title.

Before:
`item.title` would yield `"And The Mountains Echoed: "`
After:
`item.title` would yield `"And The Mountains Echoed"`